### PR TITLE
fix the field spelling issue

### DIFF
--- a/src/android/BaiduMapLocation.java
+++ b/src/android/BaiduMapLocation.java
@@ -59,7 +59,7 @@ public class BaiduMapLocation extends CordovaPlugin {
                 json.put("locType", location.getLocType());
                 json.put("locTypeDescription", location.getLocTypeDescription());
                 json.put("latitude", location.getLatitude());
-                json.put("lontitude", location.getLongitude());
+                json.put("longitude", location.getLongitude());
                 json.put("radius", location.getRadius());
 
                 json.put("countryCode", location.getCountryCode());


### PR DESCRIPTION
Hi,
定位返回的json数据字段，iOS 与 Android 两边有一个字段不一致，iOS 返回的是`longitude`，Android返回的是`lontitude`