### PR TITLE
修复调用接口提示找不到so文件的问题

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # 百度地图定位Cordova插件，支持Android，IOS，ionic 1x 2x 均可使用
 
 ### UPDATE:
+* v4.0.2 修复找不到so文件的问题
 * v4.0.1 优化了ionic3x的兼容性，升级对应百度定位依赖库（v7.5@Android）
 * v3.2.0 升级对应百度定位依赖库（v7.2@Android,v3.3.4@IOS）
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-baidumaplocation",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "description": "Cordova Geolocation Plugin,use Baidu Map SDK",
   "cordova": {
     "id": "cordova-plugin-baidumaplocation",
@@ -10,7 +10,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/aruis/cordova-plugin-baidumaplocation.git"
+    "url": "git+https://github.com/lazydan/cordova-plugin-baidumaplocation.git"
   },
   "keywords": [
     "cordova",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/lazydan/cordova-plugin-baidumaplocation.git"
+    "url": "git+https://github.com/aruis/cordova-plugin-baidumaplocation.git"
   },
   "keywords": [
     "cordova",

--- a/plugin.xml
+++ b/plugin.xml
@@ -81,7 +81,8 @@
             </service>
             <meta-data android:name="com.baidu.lbsapi.API_KEY" android:value="$ANDROID_KEY"/>
         </config-file>
-
+        
+        <framework src="src/android/BaiduMapLocation.gradle" custom="true" type="gradleReference"/>
         <source-file src="src/android/BaiduMapLocation.java" target-dir="app/src/com/aruistar/cordova/baidumap"/>
         <source-file src="libs/android/armeabi/libindoor.so" target-dir="app/libs/armeabi"/>
         <source-file src="libs/android/armeabi/liblocSDK7b.so" target-dir="app/libs/armeabi"/>

--- a/plugin.xml
+++ b/plugin.xml
@@ -21,13 +21,13 @@
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
         xmlns:android="http://schemas.android.com/apk/res/android"
         id="cordova-plugin-baidumaplocation"
-        version="4.0.1">
+        version="4.0.2">
     <name>BadiduMap Location</name>
     <description>Cordova Geolocation Plugin,use Baidu Map SDK</description>
     <license>Apache 2.0</license>
     <keywords>cordova,baidu,location,geolocation</keywords>
-    <repo>https://github.com/aruis/cordova-plugin-baidumaplocation</repo>
-    <issue>https://github.com/aruis/cordova-plugin-baidumaplocation/issues</issue>
+    <repo>https://github.com/lazydan/cordova-plugin-baidumaplocation</repo>
+    <issue>https://github.com/lazydan/cordova-plugin-baidumaplocation/issues</issue>
     
     <engines>
         <engine name="cordova-android" version=">=5.0.0" />

--- a/plugin.xml
+++ b/plugin.xml
@@ -26,8 +26,8 @@
     <description>Cordova Geolocation Plugin,use Baidu Map SDK</description>
     <license>Apache 2.0</license>
     <keywords>cordova,baidu,location,geolocation</keywords>
-    <repo>https://github.com/lazydan/cordova-plugin-baidumaplocation</repo>
-    <issue>https://github.com/lazydan/cordova-plugin-baidumaplocation/issues</issue>
+    <repo>https://github.com/aruis/cordova-plugin-baidumaplocation</repo>
+    <issue>https://github.com/aruis/cordova-plugin-baidumaplocation/issues</issue>
     
     <engines>
         <engine name="cordova-android" version=">=5.0.0" />

--- a/src/android/BaiduMapLocation.gradle
+++ b/src/android/BaiduMapLocation.gradle
@@ -1,0 +1,7 @@
+android {
+    sourceSets {
+        main {
+            jniLibs.srcDirs = ['libs']
+        }
+    }
+}


### PR DESCRIPTION
cordova: 8.0.0
cordova-android: 7.0.0
调用接口返回 找不到so文件,
在app的build.gradle文件中加上:
android {
    sourceSets {
        main {
            jniLibs.srcDirs = ['libs']
        }
    }
}